### PR TITLE
Fixed Who's Online Spacing

### DIFF
--- a/themes/default/css/portal.css
+++ b/themes/default/css/portal.css
@@ -79,7 +79,7 @@ hr {
 
 .sp_online_flow {
 	max-height: 150px;
-	height: 150px !important;;
+	height: auto !important;;
 	overflow: auto;
 }
 .sp_rss_flow {


### PR DESCRIPTION
There was additional spacing at the end of the block, and found it was
due to the !important being at width of 150, when should have been auto.
![sp_who](https://cloud.githubusercontent.com/assets/4885967/8112679/686937fa-1037-11e5-9ca3-d17c9e6ea1bf.png)

Burke Knight
