### PR TITLE
Some more RC2 updates

### DIFF
--- a/admin/ManageSPortalModule.controller.php
+++ b/admin/ManageSPortalModule.controller.php
@@ -747,9 +747,9 @@ class ManageSPortalModule_Controller extends Action_Controller
 	 */
 	public static function sp_integrate_buffer($tourniquet)
 	{
-		global $sportal_version, $context, $modSettings, $forum_copyright;
+		global $context, $modSettings, $forum_copyright;
 
-		$fix = str_replace('{version}', $sportal_version, '<a href="https://simpleportal.net/" target="_blank" class="new_win">SimplePortal {version} &copy; 2008-' . strftime('%Y') . '</a>');
+		$fix = str_replace('{version}', SPORTAL_VERSION, '<a href="https://simpleportal.net/" target="_blank" class="new_win">SimplePortal {version} &copy; 2008-' . strftime('%Y') . '</a>');
 
 		if ((ELK === 'SSI' && empty($context['standalone']))
 			|| !Template_Layers::instance()->hasLayers()

--- a/admin/PortalAdminArticles.controller.php
+++ b/admin/PortalAdminArticles.controller.php
@@ -9,6 +9,7 @@
  * @version 1.0.0 RC2
  */
 
+use BBC\PreparseCode;
 use ElkArte\Errors\AttachmentErrorContext;
 use ElkArte\Errors\ErrorContext;
 
@@ -294,17 +295,6 @@ class ManagePortalArticles_Controller extends Action_Controller
 		// Load dependency's, prepare error checking
 		$this->editInit();
 
-		// Started with HTML editor and now converting to BBC?
-		if (!empty($_REQUEST['content_mode']) && $_POST['type'] === 'bbc')
-		{
-			require_once(SUBSDIR . '/Html2BBC.class.php');
-			$convert = $_REQUEST['content'];
-			$bbc_converter = new Html_2_BBC($convert);
-			$convert = $bbc_converter->get_bbc();
-			$convert = un_htmlspecialchars($convert);
-			$_POST['content'] = $convert;
-		}
-
 		// Want to save the work?
 		if (!empty($_POST['submit']) && !$this->article_errors->hasErrors() && !$this->attach_errors->hasErrors())
 		{
@@ -329,7 +319,8 @@ class ManagePortalArticles_Controller extends Action_Controller
 		// On to the editor
 		if ($context['article']['type'] === 'bbc')
 		{
-			$context['article']['body'] = str_replace(array('"', '<', '>', '&nbsp;'), array('&quot;', '&lt;', '&gt;', ' '), un_preparsecode($context['article']['body']));
+			$context['article']['body'] = PreparseCode::instance()->un_preparsecode($context['article']['body']);
+			$context['article']['body'] = str_replace(array('"', '<', '>', '&nbsp;'), array('&quot;', '&lt;', '&gt;', ' '), $context['article']['body']);
 		}
 
 		$this->prepareEditor();
@@ -344,12 +335,8 @@ class ManagePortalArticles_Controller extends Action_Controller
 			$this->article_attachment_dd();
 		}
 
-		// Set the editor to the right mode based on type (bbc, html, php)
-		addInlineJavascript('
-			$(function() {
-				diewithfire = window.setTimeout(function() {sp_update_editor("' . $context['article']['type'] . '", "");}, 200);
-			});
-		');
+		// Set the globals, spplugin will be called with editor init to set mode
+		addConversionJS($context['article']['type']);
 
 		// Finally the main template
 		loadTemplate('PortalAdminArticles');
@@ -493,7 +480,7 @@ class ManagePortalArticles_Controller extends Action_Controller
 			'namespace' => $validator->namespace,
 			'title' => $validator->title,
 			'body' => Util::htmlspecialchars($_POST['content'], ENT_QUOTES),
-			'type' => in_array($validator->type, array('bbc', 'html', 'php')) ? $_POST['type'] : 'bbc',
+			'type' => in_array($validator->type, array('bbc', 'html', 'php', 'markdown')) ? $_POST['type'] : 'bbc',
 			'permissions' => $validator->permissions,
 			'styles' => $validator->styles,
 			'status' => !empty($_POST['status']) ? 1 : 0,
@@ -501,7 +488,7 @@ class ManagePortalArticles_Controller extends Action_Controller
 
 		if ($article_info['type'] === 'bbc')
 		{
-			preparsecode($article_info['body']);
+			PreparseCode::instance()->preparsecode($article_info['body'], false);
 		}
 
 		// Bind attachments to the article if existing, create any needed thumbnails,
@@ -700,6 +687,9 @@ class ManagePortalArticles_Controller extends Action_Controller
 				// We reuse this template for the preview
 				loadTemplate('PortalArticles');
 				$context['preview'] = true;
+
+				// The editor will steal focus so we have to delay
+				addInlineJavascript('setTimeout(() => $("html, body").animate({scrollTop: $("#preview_section").offset().top}, 250), 750);', true);
 			}
 		}
 		// Something new?
@@ -770,7 +760,7 @@ class ManagePortalArticles_Controller extends Action_Controller
 
 		if ($article['type'] === 'bbc')
 		{
-			preparsecode($article['body']);
+			PreparseCode::instance()->preparsecode($article_info['body'], false);
 		}
 
 		return $article;
@@ -792,15 +782,18 @@ class ManagePortalArticles_Controller extends Action_Controller
 		}
 
 		// Fire up the editor with the values
-		$editor_options = array(
+		$editorOptions = array(
 			'id' => 'content',
 			'value' => $context['article']['body'],
 			'width' => '100%',
 			'height' => '275px',
-			'preview_type' => 2,
+			'preview_type' => 1,
 		);
-		create_control_richedit($editor_options);
-		$context['post_box_name'] = $editor_options['id'];
+		$editorOptions['plugin_addons'] = array();
+		$editorOptions['plugin_addons'][] = 'spplugin';
+		create_control_richedit($editorOptions);
+		$context['post_box_name'] = $editorOptions['id'];
+		$context['post_box_class'] = $context['article']['type'] !== 'bbc' ? 'sceditor-container' : 'sp-sceditor-container';
 		$context['attached'] = '';
 
 		// Restore their settings

--- a/admin/PortalAdminArticles.controller.php
+++ b/admin/PortalAdminArticles.controller.php
@@ -760,7 +760,7 @@ class ManagePortalArticles_Controller extends Action_Controller
 
 		if ($article['type'] === 'bbc')
 		{
-			PreparseCode::instance()->preparsecode($article_info['body'], false);
+			PreparseCode::instance()->preparsecode($article['body'], false);
 		}
 
 		return $article;

--- a/admin/PortalAdminBlocks.controller.php
+++ b/admin/PortalAdminBlocks.controller.php
@@ -9,6 +9,7 @@
  * @version 1.0.0 RC2
  */
 
+use BBC\PreparseCode;
 
 /**
  * SimplePortal Blocks Administration controller class.
@@ -190,7 +191,7 @@ class ManagePortalBlocks_Controller extends Action_Controller
 			{
 				$context['sides'][$side_id]['last'] = $block_id;
 				$context['blocks'][$side['name']][$block_id]['status'] = '<a href="' . $scripturl . '?action=admin;area=portalblocks;sa=statechange;' . (empty($context['sp_blocks_single_side_list']) ? '' : 'redirect=' . $block['column'] . ';') . 'block_id=' . $block['id'] . ';' . $context['session_var'] . '=' . $context['session_id'] . '"
-						onclick="sp_change_status(\'' . $block['id']  . '\', \'block\', \'' . $context['session_var'] . '\', \'' . $context['session_id'] . '\');return false;">' .
+					onclick="sp_change_status(\'' . $block['id']  . '\', \'block\');return false;">' .
 					sp_embed_image(empty($block['state']) ? 'deactive' : 'active', (!empty($block['state']) ? $txt['sp-blocksDeactivate'] : $txt['sp-blocksActivate']), null, null, true, 'status_image_' . $block['id']) . '</a>';
 				$context['blocks'][$side['name']][$block_id]['actions'] = array(
 					'edit' => '&nbsp;<a href="' . $scripturl . '?action=admin;area=portalblocks;sa=edit;block_id=' . $block['id'] . ';' . $context['session_var'] . '=' . $context['session_id'] . '">' . sp_embed_image('modify') . '</a>',
@@ -702,7 +703,7 @@ class ManagePortalBlocks_Controller extends Action_Controller
 	/**
 	 * Preparse the post parameters for use
 	 *
-	 * - Cleans them as needed an places them back in $_POST
+	 * - Cleans them as needed an places them back in $_POST, yes ugly use of superglobals
 	 *
 	 * @param string $type
 	 * @param string $name
@@ -716,7 +717,7 @@ class ManagePortalBlocks_Controller extends Action_Controller
 
 			// Prepare the message a bit for some additional testing.
 			$value = Util::htmlspecialchars($value, ENT_QUOTES);
-			preparsecode($value);
+			PreparseCode::instance()->preparsecode($value, false);
 
 			// Store now the correct and fixed value ;)
 			$_POST['parameters'][$name] = $value;

--- a/controllers/PortalArticles.controller.php
+++ b/controllers/PortalArticles.controller.php
@@ -10,6 +10,7 @@
  */
 
 use BBC\ParserWrapper;
+use BBC\PreparseCode;
 
 /**
  * Article controller.
@@ -59,9 +60,7 @@ class PortalArticles_Controller extends Action_Controller
 
 		// Set up for pagination
 		$total_articles = sportal_get_articles_count();
-		$per_page = min($total_articles, !empty($modSettings['sp_articles_per_page'])
-			? $modSettings['sp_articles_per_page']
-			: 10);
+		$per_page = min($total_articles, !empty($modSettings['sp_articles_per_page']) ? $modSettings['sp_articles_per_page'] : 10);
 		$start = !empty($_REQUEST['start']) ? (int) $_REQUEST['start'] : 0;
 
 		if ($total_articles > $per_page)
@@ -163,7 +162,8 @@ class PortalArticles_Controller extends Action_Controller
 
 			// Prep the body / comment
 			$body = Util::htmlspecialchars(trim($_POST['body']));
-			preparsecode($body);
+			$preparse = PreparseCode::instance();
+			$preparse->preparsecode($body, false);
 
 			// Update or add a new comment
 			$parser = ParserWrapper::instance();
@@ -252,7 +252,7 @@ class PortalArticles_Controller extends Action_Controller
 		}
 
 		// Needed for basic Lightbox functionality
-		loadJavascriptFile('topic.js', ['defer' => true]);
+		loadJavascriptFile('topic.js', ['defer' => false]);
 
 		$context['description'] = trim(preg_replace('~<[^>]+>~', ' ', $context['article']['body']));
 		$context['description'] = Util::shorten_text(preg_replace('~\s\s+|&nbsp;|&quot;|&#039;~', ' ', $context['description']), 384, true);

--- a/controllers/PortalRefresh.controller.php
+++ b/controllers/PortalRefresh.controller.php
@@ -30,8 +30,6 @@ class PortalRefresh_Controller extends Action_Controller
 		require_once(SUBSDIR . '/Portal.subs.php');
 		require_once(SUBSDIR . '/spblocks/SPAbstractBlock.class.php');
 
-
-
 		// Not running via ssi then we need to get SSI for many block functions
 		if (ELK !== 'SSI')
 		{

--- a/controllers/PortalShoutbox.controller.php
+++ b/controllers/PortalShoutbox.controller.php
@@ -10,6 +10,7 @@
  */
 
 use BBC\ParserWrapper;
+use BBC\PreparseCode;
 
 
 /**
@@ -100,7 +101,8 @@ class Shoutbox_Controller extends Action_Controller
 				require_once(SUBSDIR . '/Post.subs.php');
 
 				$_REQUEST['shout'] = Util::htmlspecialchars(trim($_REQUEST['shout']));
-				preparsecode($_REQUEST['shout']);
+				$preparse = PreparseCode::instance();
+				$preparse->preparsecode($_REQUEST['shout'], false);
 
 				if (!empty($_REQUEST['shout']))
 				{

--- a/subs/PortalAdmin.subs.php
+++ b/subs/PortalAdmin.subs.php
@@ -479,7 +479,7 @@ function sp_load_categories($start = null, $items_per_page = null, $sort = null)
 			'articles' => $row['articles'],
 			'status' => $row['status'],
 			'status_image' => '<a href="' . $scripturl . '?action=admin;area=portalcategories;sa=status;category_id=' . $row['id_category'] . ';' . $context['session_var'] . '=' . $context['session_id'] . '"
-				onclick="sp_change_status(\'' . $row['id_category'] . '\', \'category\', \'' . $context['session_var'] . '\', \'' . $context['session_id'] . '\');return false;">' .
+				onclick="sp_change_status(\'' . $row['id_category'] . '\', \'category\');return false;">' .
 				sp_embed_image(empty($row['status']) ? 'deactive' : 'active', $txt['sp_admin_categories_' . (!empty($row['status']) ? 'de' : '') . 'activate'], null, null, true, 'status_image_' . $row['id_category']) . '</a>',
 		);
 	}
@@ -708,7 +708,7 @@ function sp_load_articles($start, $items_per_page, $sort)
 			'date' => standardTime($row['date']),
 			'status' => $row['status'],
 			'status_image' => '<a href="' . $scripturl . '?action=admin;area=portalarticles;sa=status;article_id=' . $row['id_article'] . ';' . $context['session_var'] . '=' . $context['session_id'] . '" 
-				onclick="sp_change_status(\'' . $row['id_article'] . '\', \'articles\', \'' . $context['session_var'] . '\', \'' . $context['session_id'] . '\');return false;">' .
+				onclick="sp_change_status(\'' . $row['id_article'] . '\', \'articles\');return false;">' .
 				sp_embed_image(empty($row['status']) ? 'deactive' : 'active', $txt['sp_admin_articles_' . (!empty($row['status']) ? 'de' : '') . 'activate'], null, null, true, 'status_image_' . $row['id_article']) . '</a>',
 			'actions' => array(
 				'edit' => '<a href="' . $scripturl . '?action=admin;area=portalarticles;sa=edit;article_id=' . $row['id_article'] . ';' . $context['session_var'] . '=' . $context['session_id'] . '">' . sp_embed_image('modify') . '</a>',
@@ -971,7 +971,7 @@ function sp_load_pages($start, $items_per_page, $sort)
 			'views' => $row['views'],
 			'status' => $row['status'],
 			'status_image' => '<a href="' . $scripturl . '?action=admin;area=portalpages;sa=status;page_id=' . $row['id_page'] . ';' . $context['session_var'] . '=' . $context['session_id'] . '"
-				onclick="sp_change_status(\'' . $row['id_page'] . '\', \'page\', \'' . $context['session_var'] . '\', \'' . $context['session_id'] . '\');return false;">' .
+				onclick="sp_change_status(\'' . $row['id_page'] . '\', \'page\');return false;">' .
 				sp_embed_image(empty($row['status']) ? 'deactive' : 'active', $txt['sp_admin_pages_' . (!empty($row['status']) ? 'de' : '') . 'activate'], null, null, true, 'status_image_' . $row['id_page']) . '</a>',
 			'actions' => array(
 				'edit' => '<a href="' . $scripturl . '?action=admin;area=portalpages;sa=edit;page_id=' . $row['id_page'] . ';' . $context['session_var'] . '=' . $context['session_id'] . '">' . sp_embed_image('modify') . '</a>',
@@ -2267,4 +2267,41 @@ function sp_menu_items($start, $items_per_page, $sort, $menu_id)
 	$db->free_result($request);
 
 	return $items;
+}
+
+/**
+ * SCEditor spplugin Plugin.
+ * Used to set editor initial state and the setup so type conversion can
+ * happen.  Just call the plugin with initial and new states.
+ *
+ * @param string $type
+ */
+function addConversionJS($type)
+{
+	// Set the globals, spplugin will be called with editor init to set mode
+	addInlineJavascript('
+		let start_state = "' . $type . '",
+			editor;
+			
+		$.sceditor.plugins.spplugin = function(initial_state, new_state) {
+			let base = this;
+		
+			if (typeof new_state !== "undefined")
+			{
+				sp_to_new(initial_state, new_state);
+			}
+		
+			base.init = function() {
+				editor = this;
+			};
+		
+			base.signalReady = function() {
+				if (start_state !== "bbc")
+				{
+					editor.sourceMode(true);
+					document.getElementById("editor_toolbar_container").style.display = "none";
+				}
+			};
+		};
+	');
 }

--- a/subs/spblocks/Articles.block.php
+++ b/subs/spblocks/Articles.block.php
@@ -112,6 +112,20 @@ class Articles_Block extends SP_Abstract_Block
 			return;
 		}
 
+		// Prepare what we have for the template
+		$this->prepare_data($attachments);
+
+		// Set the template name
+		$this->setTemplate('template_sp_articles');
+	}
+
+	/**
+	 * Fetches attachments, colors ID's, censors text, runs the parsers on the data
+	 *
+	 * @param bool $attachments
+	 */
+	private function prepare_data($attachments)
+	{
 		// Get the first image attachment for each article for this group
 		if (!empty($attachments) && !empty($this->data['view']))
 		{
@@ -126,9 +140,6 @@ class Articles_Block extends SP_Abstract_Block
 		{
 			$this->prepare_view();
 		}
-
-		// Set the template name
-		$this->setTemplate('template_sp_articles');
 	}
 
 	/**

--- a/subs/spblocks/Articles.block.php
+++ b/subs/spblocks/Articles.block.php
@@ -20,6 +20,7 @@
  * 		'view' => 0 compact 1 full
  * 		'length' => length for the body text preview
  * 		'avatar' => whether to show the author avatar or not
+ * 		'attachment' => Show the first attachment as "blog" image *if* no ILA tags found
  *
  * @param int $id - not used in this block
  * @param boolean $return_parameters if true returns the configuration options for the block
@@ -47,6 +48,7 @@ class Articles_Block extends SP_Abstract_Block
 			'view' => 'select',
 			'length' => 'int',
 			'avatar' => 'check',
+			'attachment' => 'check',
 		);
 
 		parent::__construct($db);
@@ -93,6 +95,7 @@ class Articles_Block extends SP_Abstract_Block
 		$category = empty($parameters['category']) ? 0 : (int) $parameters['category'];
 		$limit = empty($parameters['limit']) ? 5 : (int) $parameters['limit'];
 		$type = empty($parameters['type']) ? 0 : 1;
+		$attachments = !empty($parameters['attachment']);
 		$this->data['view'] = empty($parameters['view']) ? 0 : 1;
 		$this->data['length'] = isset($parameters['length']) ? (int) $parameters['length'] : 250;
 		$this->data['avatar'] = empty($parameters['avatar']) ? 0 : (int) $parameters['avatar'];
@@ -107,6 +110,12 @@ class Articles_Block extends SP_Abstract_Block
 			$this->setTemplate('template_sp_articles_error');
 
 			return;
+		}
+
+		// Get the first image attachment for each article for this group
+		if (!empty($attachments) && !empty($this->data['view']))
+		{
+			$this->data['articles'] = setBlogAttachments(getBlogAttachments($this->data['articles']));
 		}
 
 		// Doing the color thing
@@ -127,12 +136,10 @@ class Articles_Block extends SP_Abstract_Block
 	 */
 	private function prepare_view()
 	{
-		global $context;
-
-		require_once(SUBSDIR . '/Post.subs.php');
+		global $context, $scripturl;
 
 		// Needed for basic Lightbox functionality
-		loadJavascriptFile('topic.js', ['defer' => true]);
+		loadJavascriptFile('topic.js');
 
 		foreach ($this->data['articles'] as $aid => $article)
 		{
@@ -147,6 +154,12 @@ class Articles_Block extends SP_Abstract_Block
 			if ($this->_modSettings['sp_resize_images'])
 			{
 				$article['body'] = str_ireplace('class="bbc_img', 'class="bbc_img sp_article', $article['body']);
+			}
+
+			// Check if we need the blog attachment, no if we rendered any ILA/[sp attach] tags
+			if (strpos($article['body'], '<img src="' . $scripturl . '?action=portal;sa=spattach;article=') !== false)
+			{
+				$article['attachments'] = array();
 			}
 
 			// Account for embedded videos
@@ -296,7 +309,8 @@ function template_sp_articles($data)
 				<div class="submitbutton">
 					<a class="linkbutton" href="', $article['href'], '">', $txt['sp_read_more'], '</a>
 					<a class="linkbutton" href="', $article['href'], '#sp_view_comments">', $txt['sp_write_comment'], '</a>
-				</div></div>
+				</div>
+				</div>
 			</div>
 		</div>';
 		}

--- a/subs/spblocks/BoardNews.block.php
+++ b/subs/spblocks/BoardNews.block.php
@@ -191,6 +191,15 @@ class Board_News_Block extends SP_Abstract_Block
 				$this->color_ids[$row['id_member']] = $row['id_member'];
 			}
 
+			// If ILA is enable and what we rendered has ILA tags, assume they don't need any further attachment help
+			if (!empty($this->_modSettings['attachment_inline_enabled']))
+			{
+				if (strpos($row['body'], '<img src="' . $scripturl . '?action=dlattach;attach=') !== false)
+				{
+					$attach = array();
+				}
+			}
+
 			// Build an array of message information for output
 			$this->data['news'][] = array(
 				'id' => $row['id_topic'],
@@ -297,16 +306,7 @@ class Board_News_Block extends SP_Abstract_Block
 	 */
 	protected function getMessageAttach($id_msg, $id_topic, &$body)
 	{
-		global $topic, $modSettings;
-
-		// If ILA is enable and this post has ILA tags, assume they don't need any attachment help
-		if (!empty($modSettings['attachment_inline_enabled']))
-		{
-			if (strpos($body, '[attach') !== false)
-			{
-				return '';
-			}
-		}
+		global $topic;
 
 		if (!empty($this->attachments[$id_msg]))
 		{

--- a/subs/spblocks/SPAbstractBlock.class.php
+++ b/subs/spblocks/SPAbstractBlock.class.php
@@ -38,7 +38,9 @@ abstract class SP_Abstract_Block
 	protected $refresh = array();
 
 	/**
-	 * Class constructor, makes db available
+	 * Class constructor, makes db and modSettings available to the blocks
+	 *
+	 * - Called by sp_instantiate_block function (via block constructor)
 	 *
 	 * @param Database|null $db
 	 */
@@ -52,9 +54,11 @@ abstract class SP_Abstract_Block
 	}
 
 	/**
-	 * Returns optional block parameters
+	 * Returns block parameters used to build the ACP block "options" configuration page
 	 *
-	 * @return mixed[]
+	 * - Possible Params include boards|boards_select|check|int|select|text|textarea
+	 *
+	 * @return array
 	 */
 	public function parameters()
 	{

--- a/subs/spblocks/Shoutbox.block.php
+++ b/subs/spblocks/Shoutbox.block.php
@@ -10,6 +10,7 @@
  */
 
 use BBC\ParserWrapper;
+use BBC\PreparseCode;
 
 /**
  * Shoutbox Block, show the shoutbox thoughts box
@@ -128,7 +129,8 @@ class Shoutbox_Block extends SP_Abstract_Block
 				require_once(SUBSDIR . '/Post.subs.php');
 
 				$_POST['new_shout'] = Util::htmlspecialchars(trim($_POST['new_shout']));
-				preparsecode($_POST['new_shout']);
+				$preparse = PreparseCode::instance();
+				$preparse->preparsecode($_POST['new_shout'], false);
 
 				if (!empty($_POST['new_shout']))
 				{

--- a/themes/default/Portal.template.php
+++ b/themes/default/Portal.template.php
@@ -59,8 +59,8 @@ function template_portal_index()
 
 		echo '
 						', sprintf($article['view_count'] == 1
-			? $txt['sp_viewed_time'] : $txt['sp_viewed_times'], $article['view_count']), ', ', sprintf($article['comment_count'] == 1
-			? $txt['sp_commented_on_time'] : $txt['sp_commented_on_times'], $article['comment_count']), '
+							? $txt['sp_viewed_time'] : $txt['sp_viewed_times'], $article['view_count']), ', ', sprintf($article['comment_count'] == 1
+							? $txt['sp_commented_on_time'] : $txt['sp_commented_on_times'], $article['comment_count']), '
 					</span>
 				</div>
 				<hr />
@@ -78,7 +78,7 @@ function template_portal_index()
 	{
 		echo '
 		<div class="sp_page_index">',
-		template_pagesection(), '
+			template_pagesection(), '
 		</div>';
 	}
 
@@ -109,7 +109,7 @@ function template_portal_above()
 		{
 			echo '
 		<a id="sp_collapse_side1" class="icon ', $context['SPortal']['sides'][1]['collapsed']
-				? 'expand' : 'collapse', '" href="#side" onclick="return sp_collapseSide(1)"></a>';
+			? 'expand' : 'collapse', '" href="#side" onclick="return sp_collapseSide(1)"></a>';
 		}
 
 		if (!empty($context['SPortal']['blocks']['custom_arrange']) &&
@@ -361,7 +361,7 @@ function template_block_default($block, $side)
 		: '', '>
 							<div class="', 	$block['type'] !== 'sp_menu'
 		? 'sp_block sp_' : 'sp_content_padding sp_', strtolower($block['type']), '"',
-	!empty($block['style']['body']['style'])
+		!empty($block['style']['body']['style'])
 		? ' style="' . $block['style']['body']['style'] . '"'
 		: '', '>';
 

--- a/themes/default/PortalAdmin.template.php
+++ b/themes/default/PortalAdmin.template.php
@@ -95,9 +95,27 @@ function template_change_status()
 	global $context, $txt;
 
 	echo '<', '?xml version="1.0" encoding="UTF-8" ?', '>
-	<elk>
-		<id>', $context['item_id'], '</id>
-		<status>', $context['status'], '</status>
-		<label>', $txt['sp-blocks' . ($context['status'] === 'active' ? 'Deactivate' : 'Activate')] . '</label>
-	</elk>';
+<elk>
+	<id>', $context['item_id'], '</id>
+	<status>', $context['status'], '</status>
+	<label>', $txt['sp-blocks' . ($context['status'] === 'active' ? 'Deactivate' : 'Activate')] . '</label>
+</elk>';
+}
+
+/**
+ * Return an xml response to a format swap/change request
+ */
+function template_format_xml()
+{
+	global $context;
+
+	// Cleanup the conversion
+	$text = trim($context['SPortal']['text']);
+	$text = preg_replace("~(\s*[\n]\s*){2,}~", "\n\n", $text);
+	$text = str_replace("\n\x00", '', $text);
+
+	echo '<', '?xml version="1.0" encoding="UTF-8"?', '>
+<elk>
+	<format>', $text, '</format>
+</elk>';
 }

--- a/themes/default/PortalAdminArticles.template.php
+++ b/themes/default/PortalAdminArticles.template.php
@@ -20,7 +20,7 @@ function template_articles_edit_above()
 	// Taking a peek before you publish?
 	echo '
 	<div id="preview_section" class="forumposts"', !empty($context['preview']) ? '' : ' style="display: none;"', '>',
-	!empty($context['preview']) ? template_view_article() : '', '
+		!empty($context['preview']) ? template_view_article() : '', '
 	</div>';
 
 	// If an error occurred, explain what happened.
@@ -75,7 +75,7 @@ function template_articles_edit_above()
 						<dd>
 							<select name="type" id="article_type">';
 
-	$content_types = array('bbc', 'html', 'php');
+	$content_types = array('bbc', 'html', 'php', 'markdown');
 	foreach ($content_types as $type)
 	{
 		echo '
@@ -131,11 +131,11 @@ function template_articles()
 {
 	global $context, $txt;
 
-	echo '
-					<div>', template_control_richedit($context['post_box_name'], 'smileyBox_message', 'bbcBox_message'), '</div>
+	echo
+					template_control_richedit($context['post_box_name'], 'smileyBox_message', 'bbcBox_message'), '
 					<div class="submitbutton">
-						<input type="submit" name="submit" value="', $txt['save'], '" accesskey="s" tabindex="', $context['tabindex']++, '" class="button_submit" />
-						<input type="submit" name="preview" value="', $txt['sp_admin_articles_preview'], '" accesskey="p" tabindex="', $context['tabindex']++, '" class="button_submit" />
+						<input type="submit" name="submit" value="', $context['page_title'], '" accesskey="s" tabindex="', $context['tabindex']++, '" />
+						<input type="submit" name="preview" value="', $txt['sp_admin_articles_preview'], '" accesskey="p" tabindex="', $context['tabindex']++, '" />
 						<input type="hidden" name="article_id" value="', $context['article']['id'], '" />
 						<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />';
 
@@ -148,6 +148,7 @@ function template_articles()
 
 	echo '
 					</div>';
+
 
 	addInlineJavascript('sp_editor_change_type("article_type");', true);
 }
@@ -283,4 +284,3 @@ function template_article_new_attachments()
 	echo '
 							</dd>';
 }
-

--- a/themes/default/PortalAdminPages.template.php
+++ b/themes/default/PortalAdminPages.template.php
@@ -50,7 +50,7 @@ function template_pages_edit()
 						<dd>
 							<select name="type" id="page_type">';
 
-	$content_types = array('bbc', 'html', 'php');
+	$content_types = array('bbc', 'html', 'php', 'markdown');
 	foreach ($content_types as $type)
 		echo '
 								<option value="', $type, '"', $context['SPortal']['page']['type'] == $type ? ' selected="selected"' : '', '>', $txt['sp_pages_type_' . $type], '</option>';
@@ -99,11 +99,13 @@ function template_pages_edit()
 				<div>',
 					template_control_richedit($context['post_box_name'], 'smileyBox_message', 'bbcBox_message'), '
 				</div>
+				<div class="submitbutton">
+					<input type="submit" name="submit" value="', $context['page_title'], '" />
+					<input type="submit" name="preview" value="', $txt['sp_admin_pages_preview'], '" />
+					<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
+					<input type="hidden" name="page_id" value="', $context['SPortal']['page']['id'], '" />
+				</div>
 			</div>
-			<input type="submit" name="submit" value="', $context['page_title'], '" class="right_submit" />
-			<input type="submit" name="preview" value="', $txt['sp_admin_pages_preview'], '" class="right_submit" />
-			<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '" />
-			<input type="hidden" name="page_id" value="', $context['SPortal']['page']['id'], '" />
 		</form>
 	</div>';
 

--- a/themes/default/PortalArticles.template.php
+++ b/themes/default/PortalArticles.template.php
@@ -33,8 +33,8 @@ function template_view_articles()
 	foreach ($context['articles'] as $id => $article)
 	{
 		echo '
-			<div class="sp_content_padding">
-				<div class="sp_article_detail">';
+		<div class="sp_content_padding">
+			<div class="sp_article_detail">';
 
 		// Start off with the avatar
 		if (!empty($article['author']['avatar']['image']))
@@ -44,19 +44,18 @@ function template_view_articles()
 
 		// And now the article
 		echo '
-					<span class="sp_article_latest">
-						', sprintf(!empty($context['using_relative_time']) ? $txt['sp_posted_on_in_by'] : $txt['sp_posted_in_on_by'], $article['category']['link'], $article['date'], $article['author']['link']), '
-						<br />
-						', sprintf($article['views'] == 1 ? $txt['sp_viewed_time'] : $txt['sp_viewed_times'], $article['views']), ', ', sprintf($article['comments'] == 1 ? $txt['sp_commented_on_time'] : $txt['sp_commented_on_times'], $article['comments']), '
-					</span>
-					<h4>', $article['link'], '</h4>
-				</div>
-				<hr />
-				<div id="msg_', $id, '" class="inner sp_inner">', $article['preview'], '<a href="', $article['href'], '">...</a></div>
-				<div class="sp_article_extra clear">
-					<a class="linkbutton" href="', $article['href'], '">', $txt['sp_read_more'], '</a>
-					<a class="linkbutton" href="', $article['href'], '#sp_view_comments">', $txt['sp_write_comment'], '</a>
-				</div>
+				<span class="sp_article_latest">
+					', sprintf(!empty($context['using_relative_time']) ? $txt['sp_posted_on_in_by'] : $txt['sp_posted_in_on_by'], $article['category']['link'], $article['date'], $article['author']['link']), '
+					<br />
+					', sprintf($article['views'] == 1 ? $txt['sp_viewed_time'] : $txt['sp_viewed_times'], $article['views']), ', ', sprintf($article['comments'] == 1 ? $txt['sp_commented_on_time'] : $txt['sp_commented_on_times'], $article['comments']), '
+				</span>
+				<h4>', $article['link'], '</h4>
+			</div>
+			<div id="msg_', $id, '" class="inner sp_inner">', $article['preview'], '<a href="', $article['href'], '">...</a></div>
+			<div class="sp_article_extra clear">
+				<a class="linkbutton" href="', $article['href'], '">', $txt['sp_read_more'], '</a>
+				<a class="linkbutton" href="', $article['href'], '#sp_view_comments">', $txt['sp_write_comment'], '</a>
+			</div>
 		</div>';
 	}
 
@@ -98,25 +97,25 @@ function template_view_article()
 		echo $context['article']['author']['avatar']['image'];
 
 	echo '
-					<span class="sp_article_latest">
-						', sprintf(!empty($context['using_relative_time']) ? $txt['sp_posted_on_in_by'] : $txt['sp_posted_in_on_by'], $context['article']['category']['link'], $context['article']['date'], $context['article']['author']['link']);
+				<span class="sp_article_latest">
+					', sprintf(!empty($context['using_relative_time']) ? $txt['sp_posted_on_in_by'] : $txt['sp_posted_in_on_by'], $context['article']['category']['link'], $context['article']['date'], $context['article']['author']['link']);
 
 	if (!empty($context['article']['author']['avatar']['image']))
 		echo '
-						<br />';
+					<br />';
 	else
 		echo '
-					</span><br>
-					<span class="floatright">';
+				</span>
+				<br />
+				<span class="floatright">';
 
 	echo '
-					', sprintf($context['article']['view_count'] == 1 ? $txt['sp_viewed_time'] : $txt['sp_viewed_times'], $context['article']['view_count']), ', ',
-					sprintf($context['article']['comment_count'] == 1 ? $txt['sp_commented_on_time'] : $txt['sp_commented_on_times'], $context['article']['comment_count']), '
-					</span>
-				</div>
-				<hr />
-				<div id="msg_', $context['article']['id'], '" class="messageContent inner sp_inner">' ,
-					$context['article']['body'];
+				', sprintf($context['article']['view_count'] == 1 ? $txt['sp_viewed_time'] : $txt['sp_viewed_times'], $context['article']['view_count']), ', ',
+				sprintf($context['article']['comment_count'] == 1 ? $txt['sp_commented_on_time'] : $txt['sp_commented_on_times'], $context['article']['comment_count']), '
+				</span>
+			</div>
+			<div id="msg_', $context['article']['id'], '" class="messageContent inner sp_inner">' ,
+				$context['article']['body'];
 
 	if ($context['article']['can_moderate'] && empty($context['preview']))
 		echo '
@@ -132,7 +131,7 @@ function template_view_article()
 	}
 
 	echo '		
-				</div>
+			</div>
 		</div>';
 
 	// Not just previewing the new article, then show comments etc
@@ -225,7 +224,7 @@ function template_article_schema_script()
 	$description = Util::shorten_text(preg_replace('~\s\s+~', ' ', $post));
 
 	$smd = array(
-		'@context' => 'http://schema.org',
+		'@context' => 'https://schema.org',
 		'@type' => 'Article',
 		'headline' => $context['article']['title'],
 		'author' => array(

--- a/themes/default/PortalCategories.template.php
+++ b/themes/default/PortalCategories.template.php
@@ -9,6 +9,7 @@
  * @version 1.0.0 RC2
  */
 
+
 function template_view_categories()
 {
 	global $context, $txt;
@@ -55,13 +56,13 @@ function template_view_category()
 	if (empty($context['articles']))
 	{
 		echo '
-		<div class="sp_content_padding">', $txt['error_sp_no_articles'], '</div>';
+		<div class="infobox">', $txt['error_sp_no_articles'], '</div>';
 	}
 
 	foreach ($context['articles'] as $article)
 	{
 		echo '
-		<article class="sp_content_padding">
+		<article class="sp_article_content">
 			<div class="sp_article_detail">';
 
 		if (!empty($article['author']['avatar']['image']))
@@ -78,7 +79,25 @@ function template_view_category()
 				<h4>', $article['link'], '</h4>
 			</div>
 			<hr />
-			<div id="msg_', $article['id'], '" class="inner sp_inner">', $article['preview'], '
+			<div id="msg_', $article['id'], '" class="post inner sp_inner">';
+
+		if (!empty($article['attachments']))
+		{
+			echo '
+					<div class="sp_attachment_thumb">';
+
+			// If you want Fancybox to tag this, remove nfb_ from the id
+			echo '
+						<a href="', $article['href'], '" id="nfb_link_', $article['attachments']['id'], '">
+							<img src="', $article['attachments']['href'], '" alt="" title="', $article['attachments']['name'], '" id="thumb_', $article['attachments']['id'], '" />
+						</a>';
+
+			echo '
+					</div>';
+		}
+
+		echo
+				$article['preview'], '
 				<div class="sp_article_extra clear">',
 					(!empty($article['cut']) ? '<a class="linkbutton" href="' . $article['href'] . '">' . $txt['sp_read_more'] . '</a>' : ''),
 					(!empty($article['comment_count']) ? '<a class="linkbutton" href="' . $article['href'] . '#sp_view_comments">' . $txt['sp-articlesComments'] . '</a>' : ''),

--- a/themes/default/css/portal.css
+++ b/themes/default/css/portal.css
@@ -259,7 +259,7 @@ table.sp_articles {
 
 .sp_article_content .sp_attachment_thumb {
 	float: left;
-	margin: 5px 10px 0 0;
+	margin: 5px 10px -3px 0;
 }
 
 .sp_article_content .post:after {

--- a/themes/default/scripts/portal.js
+++ b/themes/default/scripts/portal.js
@@ -7,6 +7,8 @@
  * @version 1.0.0 RC2
  */
 
+/** global: editor, start_state */
+
 /**
  * Used to collapse an individual block
  *
@@ -16,7 +18,7 @@ function sp_collapseBlock(id)
 {
 	$("#sp_block_" + id).slideToggle(300).promise().done(function ()
 	{
-		var mode = false;
+		let mode = false;
 
 		if ($("#sp_block_" + id).is(":visible"))
 		{
@@ -45,7 +47,7 @@ function sp_collapseBlock(id)
  */
 function sp_collapseSide(id)
 {
-	var sp_sides = [];
+	let sp_sides = [];
 
 	sp_sides[1] = "sp_left";
 	sp_sides[4] = "sp_right";
@@ -77,11 +79,11 @@ function sp_collapseSide(id)
  */
 function sp_collapse_object(id, has_image)
 {
-	var mode = document.getElementById("sp_object_" + id).style.display === '' ? 0 : 1;
+	let mode = document.getElementById("sp_object_" + id).style.display === '' ? 0 : 1;
 
 	$("#sp_object_" + id).toggle(300);
 
-	if (typeof(has_image) === "undefined" || has_image === true)
+	if (typeof (has_image) === "undefined" || has_image === true)
 	{
 		document.getElementById("sp_collapse_" + id).src = elk_images_url + (mode ? '/collapse.png' : '/expand.png');
 	}
@@ -89,7 +91,7 @@ function sp_collapse_object(id, has_image)
 
 function sp_image_resize()
 {
-	var possible_images = document.getElementsByTagName("img");
+	let possible_images = document.getElementsByTagName("img");
 
 	for (var i = 0; i < possible_images.length; i++)
 	{
@@ -98,7 +100,7 @@ function sp_image_resize()
 			continue;
 		}
 
-		var temp_image = new Image();
+		let temp_image = new Image();
 		temp_image.src = possible_images[i].src;
 
 		if (temp_image.width > 300)
@@ -133,7 +135,7 @@ function sp_submit_shout(shoutbox_id, sSessionVar, sSessionId)
 	{
 		shoutbox_indicator(shoutbox_id, true);
 
-		var shout_body = document.getElementById('new_shout_' + shoutbox_id).value.replace(/&#/g, "&#38;#").php_urlencode();
+		let shout_body = document.getElementById('new_shout_' + shoutbox_id).value.replace(/&#/g, "&#38;#").php_urlencode();
 
 		sendXMLDocument(elk_prepareScriptUrl(sp_script_url) + 'action=shoutbox;xml', 'shoutbox_id=' + shoutbox_id + '&shout=' + shout_body + '&' + sSessionVar + '=' + sSessionId, onShoutReceived);
 
@@ -188,7 +190,7 @@ function sp_refresh_shout(shoutbox_id, last_refresh)
  */
 function onShoutReceived(XMLDoc)
 {
-	var shout, shouts, shoutbox_id, updated, error, warning, reverse, id, author, time,
+	let shout, shouts, shoutbox_id, updated, error, warning, reverse, id, author, time,
 		timeclean, delete_link, content, is_me, new_body = '';
 
 	// All valid response will have these
@@ -276,13 +278,13 @@ function sp_show_history_ignored_shout(shout_id)
 
 function sp_showMoreSmileys(postbox, sTitleText, sPickText, sCloseText, elk_theme_url, elk_smileys_url)
 {
-	if (typeof(this.oSmileyPopupWindow) !== "undefined" && 'closed' in this.oSmileyPopupWindow && !this.oSmileyPopupWindow.closed)
+	if (typeof (this.oSmileyPopupWindow) !== "undefined" && 'closed' in this.oSmileyPopupWindow && !this.oSmileyPopupWindow.closed)
 	{
 		this.oSmileyPopupWindow.focus();
 		return;
 	}
 
-	if (typeof(sp_smileyRowsContent) === "undefined")
+	if (typeof (sp_smileyRowsContent) === "undefined")
 	{
 		var sp_smileyRowsContent = '';
 
@@ -305,102 +307,8 @@ function sp_showMoreSmileys(postbox, sTitleText, sPickText, sCloseText, elk_them
 }
 
 /**
- * When using html or php, disable the editor so it does not "fight" with what
- * the user wants to enter.
- *
- * @param {string} new_state
- * @param {string} original set to true on first invocation from controller
- */
-function sp_update_editor(new_state, original)
-{
-	var $_textarea = $("textarea"),
-		instance = $_textarea.sceditor("instance"),
-		val = '';
-
-	// Going back to BBC
-	if (new_state === "bbc" && typeof(instance) === "undefined")
-	{
-		// Get the current textbox contents, treat as if html
-		if (original === 'html')
-		{
-			val = $_textarea.html().php_unhtmlspecialchars();
-		}
-		else
-		{
-			val = '[code]' + $_textarea.val().replace(/\n/g, '<br \>') + '[/code]';
-		}
-
-		// Start the editor again
-		elk_editor();
-
-		// load the editor with the html contents, toggle back to bbc so the editor converts it
-		instance = $_textarea.sceditor("instance");
-		instance.sourceMode(false);
-		instance.setWysiwygEditorValue(val);
-		instance.sourceMode(true);
-	}
-	// Toggling from BBC to html or php
-	else if (new_state !== "bbc" && typeof(instance) !== "undefined" && original !== '')
-	{
-		// Update the the original text area with current editor contents and stop the editor
-		if (new_state === 'html')
-		{
-			// Get the editors html value, bypass the bbc plugin, this html will have lost
-			// its formatting but it is html
-			if (instance.getSourceEditorValue() !== '')
-			{
-				val = instance.getWysiwygEditorValue(false);
-				val = val.replace(/<span .*>\s?<\/span>/g, '').replace(/<br( \\)?>/g, "\n");
-			}
-		}
-		// From bbc to php
-		else
-		{
-			val = instance.getSourceEditorValue(false).replace(/<br( \\)?>/g, "\n").php_unhtmlspecialchars().replace('[code]', '').replace('[/code]', '');
-		}
-
-		// Don't need the editor any longer, back to a text box and set the value we determined
-		instance.destroy();
-		$("textarea").val(val);
-	}
-	// Load html to the text area
-	else if (new_state !== "bbc" && typeof(instance) !== "undefined")
-	{
-		// Update the the original text area with current editor contents and stop the editor
-		if (new_state === 'html')
-		{
-			instance.updateOriginal();
-		}
-
-		instance.destroy();
-	}
-}
-
-/**
- * Monitors the onchange and focus events for an element
- *
- * @param {string} element ID of element to attach change/focus events
- */
-function sp_editor_change_type(element)
-{
-	var previous;
-
-	$('#' + element).on('focus', function ()
-	{
-		// Store the current value on focus and on change
-		previous = this.value;
-	}).change(function ()
-	{
-		// Handle the editor change
-		sp_update_editor(this.value, previous);
-
-		// Make sure the previous value is updated
-		previous = this.value;
-	});
-}
-
-/**
  * Used by the theme selection block to swap the preview image
+ *
  * @param {type} obj
  */
 function sp_theme_select(obj)
@@ -411,6 +319,7 @@ function sp_theme_select(obj)
 
 /**
  * Used to swap the day on the calendar to update the days events
+ *
  * @param {type} id
  */
 function sp_collapseCalendar(id)
@@ -429,6 +338,7 @@ function sp_collapseCalendar(id)
 
 /**
  * Admin Blocks area, used to expand the areas under advanced
+ *
  * @param {type} id
  */
 function sp_collapseObject(id)
@@ -522,17 +432,19 @@ function sp_surroundText(text1, text2, oTextHandle)
 	}
 }
 
-// Updates the current version container with the current version found in the repository
+/**
+ * Updates the current version container with the current version found in the repository
+ */
 function sp_currentVersion()
 {
-	var oSPVersionContainer = document.getElementById("spCurrentVersion"),
+	let oSPVersionContainer = document.getElementById("spCurrentVersion"),
 		oinstalledVersionContainer = document.getElementById("spYourVersion"),
 		sCurrentVersion = oinstalledVersionContainer.innerHTML;
 
 	$.getJSON('https://api.github.com/repos/SimplePortal/SimplePortal_ElkArte/releases', {format: "json"},
 		function (data, textStatus, jqXHR)
 		{
-			var mostRecent = {},
+			let mostRecent = {},
 				init_news = false;
 
 			$.each(data, function (idx, elem)
@@ -550,17 +462,23 @@ function sp_currentVersion()
 				init_news = true;
 			});
 
-			var spVersion = mostRecent.tag_name.replace(/simpleportal/i, '').trim();
+			let spVersion = mostRecent.tag_name.replace(/simpleportal/i, '').trim();
 
 			oSPVersionContainer.innerHTML = spVersion;
 			if (sCurrentVersion !== spVersion)
 			{
 				oinstalledVersionContainer.innerHTML = '<span class="alert">' + sCurrentVersion + '</span>';
 			}
-		});
+		}
+	);
 }
 
-// Load in any announcements
+/**
+ * Load in any announcements
+ *
+ * @param init_news
+ * @param announcement
+ */
 function sp_setAnnouncement(init_news, announcement)
 {
 	var oElem = document.getElementById('spAnnouncements'),
@@ -574,24 +492,33 @@ function sp_setAnnouncement(init_news, announcement)
 }
 
 /**
- * Sends and xml request to enable / disable pages, categories, articles, etc.
+ * Sends an xml request to enable / disable pages, categories, articles, etc.
  *
  * @param {int} id
  * @param {string} type
- * @param {string} session_var
- * @param {string} session_id
  * @returns {boolean}
  */
-function sp_change_status(id, type, session_var, session_id)
+function sp_change_status(id, type)
 {
 	if (type === 'articles')
-		sendXMLDocument(elk_prepareScriptUrl(elk_scripturl) + 'action=admin;area=portalarticles;sa=status;xml', 'article_id=' + id + '&' + session_var + '=' + session_id, sp_on_status_received);
-	else if (type === 'category')
-		sendXMLDocument(elk_prepareScriptUrl(elk_scripturl) + 'action=admin;area=portalcategories;sa=status;xml', 'category_id=' + id + '&' + session_var + '=' + session_id, sp_on_status_received);
-	else if (type === 'page')
-		sendXMLDocument(elk_prepareScriptUrl(elk_scripturl) + 'action=admin;area=portalpages;sa=status;xml', 'page_id=' + id + '&' + session_var + '=' + session_id, sp_on_status_received);
-	else if (type === 'block')
-		sendXMLDocument(elk_prepareScriptUrl(elk_scripturl) + 'action=admin;area=portalblocks;sa=statechange;xml', 'block_id=' + id + '&' + session_var + '=' + session_id, sp_on_status_received);
+	{
+		sendXMLDocument(elk_prepareScriptUrl(elk_scripturl) + 'action=admin;area=portalarticles;sa=status;xml', 'article_id=' + id + '&' + elk_session_var + '=' + elk_session_id, sp_on_status_received);
+	}
+
+	if (type === 'category')
+	{
+		sendXMLDocument(elk_prepareScriptUrl(elk_scripturl) + 'action=admin;area=portalcategories;sa=status;xml', 'category_id=' + id + '&' + elk_session_var + '=' + elk_session_id, sp_on_status_received);
+	}
+
+	if (type === 'page')
+	{
+		sendXMLDocument(elk_prepareScriptUrl(elk_scripturl) + 'action=admin;area=portalpages;sa=status;xml', 'page_id=' + id + '&' + elk_session_var + '=' + elk_session_id, sp_on_status_received);
+	}
+
+	if (type === 'block')
+	{
+		sendXMLDocument(elk_prepareScriptUrl(elk_scripturl) + 'action=admin;area=portalblocks;sa=statechange;xml', 'block_id=' + id + '&' + elk_session_var + '=' + elk_session_id, sp_on_status_received);
+	}
 
 	return false;
 }
@@ -610,7 +537,7 @@ function sp_on_status_received(XMLDoc)
 		return false;
 	}
 
-	var xml = XMLDoc.getElementsByTagName('elk')[0],
+	let xml = XMLDoc.getElementsByTagName('elk')[0],
 		id = xml.getElementsByTagName('id')[0].childNodes[0].nodeValue,
 		status = xml.getElementsByTagName('status')[0].childNodes[0].nodeValue,
 		label = xml.getElementsByTagName('label')[0].childNodes[0].nodeValue,
@@ -622,6 +549,91 @@ function sp_on_status_received(XMLDoc)
 		status_image.src = status_image.src.replace(old, status + '.png');
 		status_image.alt = status_image.title = label;
 	}
+
+	return false;
+}
+
+/**
+ * Monitors the onchange and focus events for the article/page type select box
+ * keeps track of previous and new states (bbc, html, markdown, etc) so conversion
+ * can be attempted.
+ *
+ * @param {string} element ID of element to attach change/focus events
+ */
+function sp_editor_change_type(element)
+{
+	var initial_state;
+
+	$('#' + element).on('focus', function ()
+	{
+		// Store the current value on focus
+		initial_state = this.value;
+	}).change(function ()
+	{
+		// Handle the editor change of format
+		$.sceditor.plugins.spplugin(initial_state, this.value);
+
+		// Make sure the previous value is updated
+		initial_state = this.value;
+	});
+}
+
+/**
+ * Convert the current editor formatting syntax to another language
+ *
+ * @param {string} initial_state one of bbc, html, markdown, php
+ * @param {string} new_state one of bbc, html, markdown, php
+ */
+function sp_to_new(initial_state, new_state) {
+	// Get the current contents and send to off for conversion
+	let val = editor.getSourceEditorValue(false);
+
+	// Send it to the server for conversion
+	sp_change_format(val, initial_state, new_state);
+
+	// If BBC show the editor toolbar
+	document.getElementById("editor_toolbar_container").style.display = (new_state === 'bbc' ? 'block' : 'none');
+}
+
+/**
+ * Sends an xml request to change the format of the editor box
+ *
+ * @param {string} text The current text
+ * @param {string} from Going to bbc, html, php, markdown
+ * @param {string} to Going to bbc, html, php, markdown
+ * @returns {boolean}
+ */
+function sp_change_format(text, from, to)
+{
+	text = text.replace(/&#/g, "&#38;#").php_urlencode();
+	sendXMLDocument(elk_prepareScriptUrl(elk_scripturl) + 'action=admin;area=portalconfig;sa=formatchange;xml', 'text=' + text + '&' + 'from=' + from + '&' + 'to=' + to + '&' + elk_session_var + '=' + elk_session_id, sp_on_format_received);
+
+	return false;
+}
+
+/**
+ * Callback function for XML format ... updates the editor as needed.
+ *
+ * @param XMLDoc
+ * @returns {boolean}
+ */
+function sp_on_format_received(XMLDoc)
+{
+	// If it is not valid then clean up
+	if (!XMLDoc || !XMLDoc.getElementsByTagName('elk'))
+	{
+		return false;
+	}
+
+	let xml = XMLDoc.getElementsByTagName('elk')[0],
+		val = xml.getElementsByTagName('format')[0].firstChild;
+
+	val = val !== null ? val.nodeValue : '';
+
+	// Put the response in the editor wizzy and then toggle back to source
+	editor.sourceMode(false);
+	editor.val(val, true);
+	editor.sourceMode(true);
 
 	return false;
 }


### PR DESCRIPTION
 - Add ability to use markdown syntax in articles and pages
 - Improve first attachment option to show as long as an ILA tag was not rendered in the displayed snippet (no rendered ILA before cutoff or character limits)
 - Change the way format conversion worked for all conversions (ie markdown->bbc, bbc->html, html->bbc etc)
 - Change the way editor initialization worked but using simple plugin model
 - Minor template cleanup in a few areas